### PR TITLE
fix: remove ACL header from presigned PUT

### DIFF
--- a/seosa/src/main/java/com/seosa/seosa/domain/s3/service/S3Service.java
+++ b/seosa/src/main/java/com/seosa/seosa/domain/s3/service/S3Service.java
@@ -2,8 +2,6 @@ package com.seosa.seosa.domain.s3.service;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.Headers;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,11 +40,6 @@ public class S3Service {
         GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
                 .withMethod(HttpMethod.PUT)
                 .withExpiration(getPresignedUrlExpiration());
-
-        generatePresignedUrlRequest.addRequestParameter(
-                Headers.S3_CANNED_ACL,
-                CannedAccessControlList.PublicRead.toString()
-        );
 
         return generatePresignedUrlRequest;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Presigned upload URLs no longer force public-read permissions; uploads now inherit bucket/object defaults.
  * Impact: Newly uploaded files may not be publicly accessible unless allowed by your bucket settings, and access may require authentication. Existing upload flow, link generation, and expiration remain unchanged. If you rely on public links immediately after upload, verify your bucket permissions or adjust your retrieval logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->